### PR TITLE
sendmail: return errors from NewAttachment

### DIFF
--- a/sendmail/attachment_test.go
+++ b/sendmail/attachment_test.go
@@ -28,8 +28,10 @@ func TestNewAttacement(t *testing.T) {
 	})
 
 	a := Attachment{}
-	result := a.NewAttachment()
-
+	result, err := a.NewAttachment()
+	if err != nil {
+		t.Errorf("NewAttachment returned error: %v", err)
+	}
 	// 驗證結果是否為 true
 	if !result {
 		t.Errorf("Expected NewAttachment to return true, but got false")

--- a/sendmail/use_direct_send.go
+++ b/sendmail/use_direct_send.go
@@ -203,7 +203,11 @@ func SendMailWithMultipart(key string) (bool, error) {
 	{
 		// 附件夾檔部分 若用戶沒給檔案或是無效則跳過
 		attachment := Attachment{}
-		ok := attachment.NewAttachment()
+		ok, err := attachment.NewAttachment()
+		if err != nil {
+			log.Println("Error:", err)
+			return false, err
+		}
 		if ok {
 			partAttachHead := textproto.MIMEHeader{}
 			partAttachHead.Set("Content-Type", attachment.ContentType)


### PR DESCRIPTION
## Summary
- propagate errors instead of exiting in attachment creation
- handle attachment errors at send time
- adjust tests for new signature

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b05ffcee2c832792bd749786b71ac3