### PR TITLE
feat: add optional cc for direct send

### DIFF
--- a/cmd/direct_send_cmd.go
+++ b/cmd/direct_send_cmd.go
@@ -24,6 +24,7 @@ func init() {
 	var port string
 	var SenderEmail string
 	var receiverEmail string
+	var ccEmail string
 	var emailSubject string
 	var emailBody string
 
@@ -59,6 +60,9 @@ func init() {
 	directSendMailCmd.PersistentFlags().StringVar(&emailBody, "contents", "", "設定郵件內容")
 	directSendMailCmd.MarkPersistentFlagRequired("contents")
 
+	// 使用 '--cc' flag 來設定副本電子郵件地址
+	directSendMailCmd.PersistentFlags().StringVar(&ccEmail, "cc", "", "設定副本電子郵件地址 (可多個，以逗號分隔)")
+
 	// 將 flag 綁定到 viper 配置中 統一管理且方便在其他檔案使用
 	viper.BindPFlag("host", directSendMailCmd.PersistentFlags().Lookup("host"))
 	viper.BindPFlag("port", directSendMailCmd.PersistentFlags().Lookup("port"))
@@ -66,4 +70,5 @@ func init() {
 	viper.BindPFlag("to", directSendMailCmd.PersistentFlags().Lookup("to"))
 	viper.BindPFlag("subject", directSendMailCmd.PersistentFlags().Lookup("subject"))
 	viper.BindPFlag("contents", directSendMailCmd.PersistentFlags().Lookup("contents"))
+	viper.BindPFlag("cc", directSendMailCmd.PersistentFlags().Lookup("cc"))
 }

--- a/sendmail/direct_send_mail_test.go
+++ b/sendmail/direct_send_mail_test.go
@@ -1,0 +1,66 @@
+package sendmail
+
+import (
+	"net/smtp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// 測試沒有 cc 時收件者與訊息
+func TestDirectSendMailWithoutCc(t *testing.T) {
+	viper.Reset()
+	viper.Set("host", "smtp.example.com")
+	viper.Set("port", "25")
+	viper.Set("from", "from@example.com")
+	viper.Set("to", "to@example.com")
+	viper.Set("subject", "test")
+	viper.Set("contents", "body")
+
+	var gotRecipients []string
+	var gotMsg string
+	mock := func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		gotRecipients = append([]string{}, to...)
+		gotMsg = string(msg)
+		return nil
+	}
+
+	DirectSendMail(mock)
+
+	if len(gotRecipients) != 1 || gotRecipients[0] != "to@example.com" {
+		t.Errorf("收件人應只有 to, got %v", gotRecipients)
+	}
+	if strings.Contains(gotMsg, "Cc:") {
+		t.Errorf("不應包含 Cc 標頭")
+	}
+}
+
+// 測試有 cc 時收件者與訊息
+func TestDirectSendMailWithCc(t *testing.T) {
+	viper.Reset()
+	viper.Set("host", "smtp.example.com")
+	viper.Set("port", "25")
+	viper.Set("from", "from@example.com")
+	viper.Set("to", "to@example.com")
+	viper.Set("cc", "cc@example.com")
+	viper.Set("subject", "test")
+	viper.Set("contents", "body")
+
+	var gotRecipients []string
+	var gotMsg string
+	mock := func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		gotRecipients = append([]string{}, to...)
+		gotMsg = string(msg)
+		return nil
+	}
+
+	DirectSendMail(mock)
+
+	if len(gotRecipients) != 2 {
+		t.Errorf("收件人應包含 to 與 cc, got %v", gotRecipients)
+	}
+	if !strings.Contains(gotMsg, "Cc: cc@example.com") {
+		t.Errorf("應包含 Cc 標頭, got %s", gotMsg)
+	}
+}

--- a/sendmail/use_direct_send.go
+++ b/sendmail/use_direct_send.go
@@ -35,16 +35,28 @@ func DirectSendMail(s SendMailFunc) {
 	host := viper.GetString("host")
 	port := viper.GetString("port")
 	from := viper.GetString("from")
-	to := viper.GetString("to")
+	toInput := viper.GetString("to")
+	ccInput := viper.GetString("cc")
 	// password := "yourpassword"
 	subject := viper.GetString("subject") + "\r\n"
 	contents := viper.GetString("contents")
+
+	// 驗證並整理收件者與副本地址
+	toEmails, _ := utils.ValidateEmails(toInput)
+	ccEmails, _ := utils.ValidateEmails(ccInput)
+	recipients := append([]string{}, toEmails...)
+	recipients = append(recipients, ccEmails...)
+
+	to := strings.Join(toEmails, ",")
+	cc := strings.Join(ccEmails, ",")
 
 	// 設置 MIME 標頭
 	headers := make(map[string]string)
 	headers["From"] = from
 	headers["To"] = to
-	headers["Cc"] = "weiting.shi1982@gmail.com"
+	if cc != "" {
+		headers["Cc"] = cc
+	}
 	headers["Subject"] = encodeRFC2047(subject)
 	headers["MIME-Version"] = "1.0"
 	// 設定 utf-8
@@ -63,7 +75,7 @@ func DirectSendMail(s SendMailFunc) {
 
 	// 設定 SMTP 伺服器資訊
 	// auth := smtp.PlainAuth("", from, password, smtpHost)
-	err := s(host+":"+port, nil, from, []string{to}, []byte(msg))
+	err := s(host+":"+port, nil, from, recipients, []byte(msg))
 	if err != nil {
 		log.Println("Error:", err)
 		return


### PR DESCRIPTION
## Summary
- allow DirectSendMail to read optional Cc from viper and send to recipients
- add `--cc` CLI flag for `directSendMail`
- cover DirectSendMail behavior with unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b05ffa2a588327b16a00f36ba6cdd2