### PR TITLE
add utility tests

### DIFF
--- a/utils/extract_file_test.go
+++ b/utils/extract_file_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"embed"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wtg42/hermes/assets"
+)
+
+//go:embed testdata/dummy.txt
+var testFiles embed.FS
+
+func TestExtractFile(t *testing.T) {
+	// 替換原始靜態資源為測試用資料
+	original := assets.StaticFiles
+	assets.StaticFiles = testFiles
+	defer func() { assets.StaticFiles = original }()
+
+	// 呼叫被測函式
+	path, err := ExtractFile("testdata/dummy.txt")
+	assert.NoError(t, err)
+	t.Cleanup(func() { os.Remove(path) })
+
+	// 讀取檔案內容並驗證
+	data, err := os.ReadFile(path)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world\n", string(data))
+}

--- a/utils/filter_anything_test.go
+++ b/utils/filter_anything_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterNumeric(t *testing.T) {
+	assert.Equal(t, "12345", FilterNumeric("a1b2c3d4e5"))
+	assert.Equal(t, "", FilterNumeric("abc"))
+	assert.Equal(t, "2468", FilterNumeric("\n2@4#6$8"))
+}
+
+func TestValidateEmails(t *testing.T) {
+	valid, invalid := ValidateEmails("foo@example.com, bar@example.org, bad@, \t baz@domain")
+	assert.Equal(t, []string{"foo@example.com", "bar@example.org"}, valid)
+	assert.Equal(t, []string{"bad@", "baz@domain"}, invalid)
+
+	valid, invalid = ValidateEmails("")
+	assert.Empty(t, valid)
+	assert.Equal(t, []string{""}, invalid)
+}

--- a/utils/memi_type_test.go
+++ b/utils/memi_type_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMIMEType(t *testing.T) {
+	// text file
+	txt, err := os.CreateTemp("", "sample*.txt")
+	assert.NoError(t, err)
+	// 寫入超過 512 bytes 的純文字，避免被當成二進位資料
+	_, err = txt.WriteString(strings.Repeat("a", 600))
+	assert.NoError(t, err)
+	txt.Close()
+	t.Cleanup(func() { os.Remove(txt.Name()) })
+
+	mime, err := GetMIMEType(txt.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, "text/plain; charset=utf-8", mime)
+
+	// png file
+	pngFile, err := os.CreateTemp("", "img*.png")
+	assert.NoError(t, err)
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{255, 0, 0, 255})
+	err = png.Encode(pngFile, img)
+	assert.NoError(t, err)
+	pngFile.Close()
+	t.Cleanup(func() { os.Remove(pngFile.Name()) })
+
+	mime, err = GetMIMEType(pngFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, "image/png", mime)
+
+	// pdf file
+	pdfFile, err := os.CreateTemp("", "doc*.pdf")
+	assert.NoError(t, err)
+	_, err = pdfFile.Write([]byte("%PDF-1.4\n"))
+	assert.NoError(t, err)
+	pdfFile.Close()
+	t.Cleanup(func() { os.Remove(pdfFile.Name()) })
+
+	mime, err = GetMIMEType(pdfFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, "application/pdf", mime)
+}

--- a/utils/rand_anything_test.go
+++ b/utils/rand_anything_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomEmail(t *testing.T) {
+	domains := []string{"a.com", "b.org"}
+	email1 := RandomEmail(domains)
+	email2 := RandomEmail(domains)
+	assert.NotEqual(t, email1, email2) // 應具有隨機性
+
+	parts := strings.Split(email1, "@")
+	assert.Len(t, parts, 2)
+	assert.Contains(t, domains, parts[1])
+	assert.NotEmpty(t, parts[0])
+}
+
+func TestRandomInt(t *testing.T) {
+	seen := map[int]bool{}
+	for i := 0; i < 50; i++ {
+		v := RandomInt(10)
+		assert.True(t, v >= 0 && v < 10)
+		seen[v] = true
+	}
+	assert.Greater(t, len(seen), 1) // 至少出現過兩個不同值
+	assert.Equal(t, 0, RandomInt(1))
+}
+
+func TestRandomString(t *testing.T) {
+	s1 := RandomString(8)
+	s2 := RandomString(8)
+	assert.Len(t, s1, 8)
+	assert.Len(t, s2, 8)
+	assert.NotEqual(t, s1, s2)
+	assert.Equal(t, "", RandomString(0))
+	for _, c := range s1 {
+		assert.True(t, strings.ContainsRune(letters, c))
+	}
+}

--- a/utils/testdata/dummy.txt
+++ b/utils/testdata/dummy.txt
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
## Summary
- add tests for extracting embedded files using a stub FS
- ensure filtering and validation helpers handle numeric and email inputs
- cover MIME detection and random generators with boundary cases

## Testing
- `go test ./utils`


------
https://chatgpt.com/codex/tasks/task_e_68b067e9c7648327b81139d5ac6b94fa