### PR TITLE
test(cmd): add command tests

### DIFF
--- a/cmd/burst_cmd_test.go
+++ b/cmd/burst_cmd_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"net/smtp"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/wtg42/hermes/sendmail"
+)
+
+// TestBurstCmdMissingRequiredFlags 確認缺少必填旗標時回傳錯誤
+func TestBurstCmdMissingRequiredFlags(t *testing.T) {
+	viper.Reset()
+	root := &cobra.Command{Use: "hermes"}
+	root.AddCommand(burstModeCmd)
+	// 重新綁定旗標到 viper，避免 Reset 後遺失設定
+	viper.BindPFlag("burst-quantity", burstModeCmd.PersistentFlags().Lookup("quantity"))
+	viper.BindPFlag("burst-host", burstModeCmd.PersistentFlags().Lookup("host"))
+	viper.BindPFlag("burst-port", burstModeCmd.PersistentFlags().Lookup("port"))
+
+	root.SetArgs([]string{"burst"})
+	_, err := root.ExecuteC()
+	if err == nil {
+		t.Fatalf("預期缺少旗標時應回傳錯誤")
+	}
+}
+
+// TestBurstCmdRunCalled 確認提供旗標時 Run 會被執行
+func TestBurstCmdRunCalled(t *testing.T) {
+	viper.Reset()
+	root := &cobra.Command{Use: "hermes"}
+	root.AddCommand(burstModeCmd)
+	// 重新綁定旗標到 viper，避免 Reset 後遺失設定
+	viper.BindPFlag("burst-quantity", burstModeCmd.PersistentFlags().Lookup("quantity"))
+	viper.BindPFlag("burst-host", burstModeCmd.PersistentFlags().Lookup("host"))
+	viper.BindPFlag("burst-port", burstModeCmd.PersistentFlags().Lookup("port"))
+
+	called := false
+	original := sendmail.SendMail
+	sendmail.SendMail = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		called = true
+		return nil
+	}
+	defer func() { sendmail.SendMail = original }()
+
+	root.SetArgs([]string{"burst", "--quantity", "1", "--host", "smtp.example.com", "--port", "25"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("執行命令應無錯誤: %v", err)
+	}
+	if !called {
+		t.Fatalf("預期 SendMail 被呼叫")
+	}
+}

--- a/cmd/direct_send_cmd_test.go
+++ b/cmd/direct_send_cmd_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"net/smtp"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/wtg42/hermes/sendmail"
+)
+
+// TestDirectSendCmdMissingRequiredFlags 確認缺少必填旗標會回傳錯誤
+func TestDirectSendCmdMissingRequiredFlags(t *testing.T) {
+	viper.Reset()
+	root := &cobra.Command{Use: "hermes"}
+	root.AddCommand(directSendMailCmd)
+	// 重新綁定旗標到 viper，避免 Reset 後遺失設定
+	viper.BindPFlag("host", directSendMailCmd.PersistentFlags().Lookup("host"))
+	viper.BindPFlag("port", directSendMailCmd.PersistentFlags().Lookup("port"))
+	viper.BindPFlag("from", directSendMailCmd.PersistentFlags().Lookup("from"))
+	viper.BindPFlag("to", directSendMailCmd.PersistentFlags().Lookup("to"))
+	viper.BindPFlag("subject", directSendMailCmd.PersistentFlags().Lookup("subject"))
+	viper.BindPFlag("contents", directSendMailCmd.PersistentFlags().Lookup("contents"))
+	viper.BindPFlag("cc", directSendMailCmd.PersistentFlags().Lookup("cc"))
+
+	root.SetArgs([]string{"directSendMail"})
+	_, err := root.ExecuteC()
+	if err == nil {
+		t.Fatalf("預期缺少旗標時應回傳錯誤")
+	}
+}
+
+// TestDirectSendCmdRunCalled 確認提供旗標時 Run 會執行
+func TestDirectSendCmdRunCalled(t *testing.T) {
+	viper.Reset()
+	root := &cobra.Command{Use: "hermes"}
+	root.AddCommand(directSendMailCmd)
+	// 重新綁定旗標到 viper，避免 Reset 後遺失設定
+	viper.BindPFlag("host", directSendMailCmd.PersistentFlags().Lookup("host"))
+	viper.BindPFlag("port", directSendMailCmd.PersistentFlags().Lookup("port"))
+	viper.BindPFlag("from", directSendMailCmd.PersistentFlags().Lookup("from"))
+	viper.BindPFlag("to", directSendMailCmd.PersistentFlags().Lookup("to"))
+	viper.BindPFlag("subject", directSendMailCmd.PersistentFlags().Lookup("subject"))
+	viper.BindPFlag("contents", directSendMailCmd.PersistentFlags().Lookup("contents"))
+	viper.BindPFlag("cc", directSendMailCmd.PersistentFlags().Lookup("cc"))
+
+	called := false
+	originalRun := directSendMailCmd.Run
+	directSendMailCmd.Run = func(cmd *cobra.Command, args []string) {
+		sendmail.DirectSendMail(func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+			called = true
+			return nil
+		})
+	}
+	defer func() { directSendMailCmd.Run = originalRun }()
+
+	root.SetArgs([]string{
+		"directSendMail",
+		"--host", "smtp.example.com",
+		"--port", "25",
+		"--from", "from@example.com",
+		"--to", "to@example.com",
+		"--subject", "hi",
+		"--contents", "body",
+	})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("執行命令應無錯誤: %v", err)
+	}
+	if !called {
+		t.Fatalf("預期郵件發送函式被呼叫")
+	}
+}

--- a/cmd/tui_cmd_test.go
+++ b/cmd/tui_cmd_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+	"github.com/wtg42/hermes/tui"
+)
+
+// TestStartTuiCmdRunCalled 確認 Run 會呼叫 TUI
+func TestStartTuiCmdRunCalled(t *testing.T) {
+	root := &cobra.Command{Use: "hermes"}
+	root.AddCommand(startTUICmd)
+
+	called := false
+	original := tui.StartMenu
+	tui.StartMenu = func() (int, bool, tea.Model) {
+		called = true
+		return 0, true, nil
+	}
+	defer func() { tui.StartMenu = original }()
+
+	root.SetArgs([]string{"start-tui"})
+	if _, err := root.ExecuteC(); err != nil {
+		t.Fatalf("執行命令應無錯誤: %v", err)
+	}
+	if !called {
+		t.Fatalf("預期 StartMenu 被呼叫")
+	}
+}

--- a/tui/menu.go
+++ b/tui/menu.go
@@ -135,8 +135,9 @@ func (m menuModel) View() string {
 }
 
 // StartMenu TUI 程式畫面的起點
+//   - 以變數函式形式提供，方便測試時進行替換
 //   - 回傳使用者選擇的索引、是否完成以及最終模型
-func StartMenu() (int, bool, tea.Model) {
+var StartMenu = func() (int, bool, tea.Model) {
 	m := initialMenuModel()
 	p := tea.NewProgram(m)
 	finalModel, err := p.Run()


### PR DESCRIPTION
## Summary
- stub `tui.StartMenu` for easier testing
- add tests covering burst, direct send and TUI commands

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b06d60f7948327a090cfc0a62b97e9