### PR TITLE
fix: prevent form from being clipped in TUI form

### DIFF
--- a/tui/mail_field.go
+++ b/tui/mail_field.go
@@ -338,7 +338,9 @@ func (m MailFieldsModel) getFormLayout() string {
 	)
 	b.WriteString(renderString + helpText)
 
-	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, b.String())
+	// 將表單置中顯示，當內容高度超出視窗時，
+	// 改以置頂對齊避免上方被裁切
+	return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Top, b.String())
 }
 
 func (m MailFieldsModel) countEscTwice(msg tea.Msg) bool {

--- a/tui/menu.go
+++ b/tui/menu.go
@@ -142,7 +142,10 @@ func (m menuModel) View() string {
 //   - 回傳使用者選擇的索引、是否完成以及最終模型
 var StartMenu = func() (int, bool, tea.Model) {
 	m := initialMenuModel()
-	p := tea.NewProgram(m, menuProgramOptions...)
+
+	// 預設使用 AltScreen，確保畫面從新頁面開始避免被 shell 內容影響
+	opts := append(menuProgramOptions, tea.WithAltScreen())
+	p := tea.NewProgram(m, opts...)
 	finalModel, err := p.Run()
 	if err != nil {
 		log.Fatalf("發生錯誤：%v", err)


### PR DESCRIPTION
## Summary
- avoid trimming top of form by aligning layout to screen top
- start TUI on AltScreen to prevent shell leftovers

## Testing
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_68b189b27344832782c95f5e7859fed3